### PR TITLE
fix: reactivate code security configuration reconciliation, rename some workflow jobs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,5 @@
 name: Lint
+# used as pull request required check
 
 on:
   push:
@@ -6,7 +7,7 @@ on:
 
 jobs:
   lint:
-    name: Run on Ubuntu
+    name: Lint
     runs-on: ubuntu-latest
     steps:
       - name: Clone the code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   test:
-    name: Test
+    name: Pre-Release Test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -27,8 +27,10 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Run tests
-        run: make test
+      - name: Running Tests
+        run: |
+          go mod tidy
+          make test
 
   build-and-publish:
     name: Build & Publish Image

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test-e2e:
-    name: Run on Ubuntu
+    name: Test e2e
     runs-on: ubuntu-latest
     if: false # disabled until fixed
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,5 @@
 name: Tests
+# used as pull request required check
 
 on:
   push:
@@ -6,7 +7,7 @@ on:
 
 jobs:
   test:
-    name: Run on Ubuntu
+    name: Test
     runs-on: ubuntu-latest
     steps:
       - name: Clone the code

--- a/internal/reconciler/orgrec/reconciler.go
+++ b/internal/reconciler/orgrec/reconciler.go
@@ -52,7 +52,7 @@ func (o *GitHubOrgReconciler) RequiredReconciliations() []reconciler.ParallelRec
 			{Function: o.reconcileOrganization, Condition: conditions.TypeBaseSettingsSynced},
 			{Function: o.reconcileCustomProperties, Condition: conditions.TypeCustomPropertyDefinitionsSynced},
 			{Function: o.reconcileRulesetPresets, Condition: conditions.TypeRulesetsSynced},
-			// {Function: o.reconcileCodeSecurityConfigurations, Condition: conditions.TypeCodeSecurityConfigurationsSynced},
+			{Function: o.reconcileCodeSecurityConfigurations, Condition: conditions.TypeCodeSecurityConfigurationsSynced},
 			{Function: o.reconcileActionsSettings, Condition: conditions.TypeActionsConfigurationSynced},
 		},
 	}


### PR DESCRIPTION
CSC reconciliation had been disabled because of temporarily receiving HTTP 500 from GitHub upon update. This issue seems to have been fixed.