### PR TITLE
fix: retry failed modifying csc operations

### DIFF
--- a/internal/ghclient/factory.go
+++ b/internal/ghclient/factory.go
@@ -238,8 +238,14 @@ func (m *CachingGitHubClientFactory) buildMiddlewareStack(clientName string, app
 
 	// Request logging (if enabled) - TODO: Implement when logging package is available
 	// retry
-	retryFn := rehttp.RetryAll(rehttp.RetryStatusInterval(500, 600), rehttp.RetryMaxRetries(3))
-	delayFn := rehttp.ExpJitterDelay(1*time.Second, 10*time.Second)
+	retryFn := rehttp.RetryAll(
+		rehttp.RetryAny(
+			rehttp.RetryStatusInterval(500, 600), // 5xx server errors
+			retryByContextCodes,                  // per-request retryable codes via context
+		),
+		rehttp.RetryMaxRetries(5),
+	)
+	delayFn := rehttp.ExpJitterDelay(5*time.Second, 30*time.Second)
 	rt = rehttp.NewTransport(rt, retryFn, delayFn)
 
 	// Pagination handling

--- a/internal/ghclient/factory_test.go
+++ b/internal/ghclient/factory_test.go
@@ -1,8 +1,11 @@
 package ghclient
 
 import (
+	"context"
+	"net/http"
 	"testing"
 
+	"github.com/PuerkitoBio/rehttp"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -216,6 +219,65 @@ invalid-base64-data-that-cannot-be-parsed-as-rsa-key
 			_, err := parseGithubPrivateKey(pemData)
 			Expect(err).To(HaveOccurred())
 		})
+	})
+})
+
+var _ = Describe("retryByContextCodes", func() {
+	It("should retry when context has matching status code", func() {
+		ctx := WithRetryableStatusCodes(context.Background(), http.StatusConflict)
+		req, _ := http.NewRequestWithContext(ctx, "PATCH", "https://api.github.com/orgs/my-org/code-security/configurations/123", nil)
+		att := rehttp.Attempt{
+			Request:  req,
+			Response: &http.Response{StatusCode: http.StatusConflict},
+		}
+		Expect(retryByContextCodes(att)).To(BeTrue())
+	})
+
+	It("should NOT retry when context has no retryable codes", func() {
+		req, _ := http.NewRequestWithContext(context.Background(), "PATCH", "https://api.github.com/orgs/my-org/code-security/configurations/123", nil)
+		att := rehttp.Attempt{
+			Request:  req,
+			Response: &http.Response{StatusCode: http.StatusConflict},
+		}
+		Expect(retryByContextCodes(att)).To(BeFalse())
+	})
+
+	It("should NOT retry when response code does not match context codes", func() {
+		ctx := WithRetryableStatusCodes(context.Background(), http.StatusConflict)
+		req, _ := http.NewRequestWithContext(ctx, "GET", "https://api.github.com/repos/my-org/my-repo", nil)
+		att := rehttp.Attempt{
+			Request:  req,
+			Response: &http.Response{StatusCode: http.StatusNotFound},
+		}
+		Expect(retryByContextCodes(att)).To(BeFalse())
+	})
+
+	It("should NOT retry when response is nil", func() {
+		ctx := WithRetryableStatusCodes(context.Background(), http.StatusConflict)
+		req, _ := http.NewRequestWithContext(ctx, "PATCH", "https://api.github.com/test", nil)
+		att := rehttp.Attempt{
+			Request:  req,
+			Response: nil,
+		}
+		Expect(retryByContextCodes(att)).To(BeFalse())
+	})
+
+	It("should NOT retry when request is nil", func() {
+		att := rehttp.Attempt{
+			Request:  nil,
+			Response: &http.Response{StatusCode: http.StatusConflict},
+		}
+		Expect(retryByContextCodes(att)).To(BeFalse())
+	})
+
+	It("should support multiple retryable codes", func() {
+		ctx := WithRetryableStatusCodes(context.Background(), http.StatusConflict, http.StatusTooManyRequests)
+		req, _ := http.NewRequestWithContext(ctx, "POST", "https://api.github.com/test", nil)
+		att := rehttp.Attempt{
+			Request:  req,
+			Response: &http.Response{StatusCode: http.StatusTooManyRequests},
+		}
+		Expect(retryByContextCodes(att)).To(BeTrue())
 	})
 })
 

--- a/internal/ghclient/retry.go
+++ b/internal/ghclient/retry.go
@@ -1,0 +1,38 @@
+package ghclient
+
+import (
+	"context"
+
+	"github.com/PuerkitoBio/rehttp"
+	"golang.org/x/exp/slices"
+)
+
+type retryableStatusCodesKey struct{}
+
+// WithRetryableStatusCodes returns a new context that instructs the HTTP transport
+// retry middleware to retry requests that receive any of the given HTTP status codes.
+//
+// Usage at call site:
+//
+//	ctx = ghclient.WithRetryableStatusCodes(ctx, http.StatusConflict)
+//	client.UpdateCodeSecurityConfigurationForOrg(ctx, ...)
+func WithRetryableStatusCodes(ctx context.Context, codes ...int) context.Context {
+	return context.WithValue(ctx, retryableStatusCodesKey{}, codes)
+}
+
+// retryableStatusCodesFromContext extracts the retryable status codes from the context, if any.
+func retryableStatusCodesFromContext(ctx context.Context) []int {
+	codes, _ := ctx.Value(retryableStatusCodesKey{}).([]int)
+	return codes
+}
+
+// retryByContextCodes is a rehttp.RetryFn that retries a request only if its context
+// has been annotated with WithRetryableStatusCodes and the response status code matches
+// one of those codes. This makes retry intent explicit and visible at the call site.
+func retryByContextCodes(att rehttp.Attempt) bool {
+	if att.Response == nil || att.Request == nil {
+		return false
+	}
+	codes := retryableStatusCodesFromContext(att.Request.Context())
+	return slices.Contains(codes, att.Response.StatusCode)
+}

--- a/internal/reconciler/orgrec/rec_code_security_configurations.go
+++ b/internal/reconciler/orgrec/rec_code_security_configurations.go
@@ -5,10 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"net/http"
 	"slices"
 	"time"
 
 	githubv1alpha1 "github.com/Interhyp/git-hubby/api/v1alpha1"
+	"github.com/Interhyp/git-hubby/internal/ghclient"
 	"github.com/Interhyp/git-hubby/internal/mapper"
 	"github.com/google/go-github/v86/github"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -18,6 +20,10 @@ import (
 const targetTypeOrganization = "organization"
 
 func (o *GitHubOrgReconciler) reconcileCodeSecurityConfigurations(ctx context.Context) error {
+	// GitHub returns 409 on code-security configuration endpoints when an enablement
+	// event is in progress. This is transient and should be retried at the transport level.
+	ctx = ghclient.WithRetryableStatusCodes(ctx, http.StatusConflict)
+
 	log := logPkg.FromContext(ctx)
 	log.V(1).Info("Reconciling organization code security configurations on GitHub")
 
@@ -290,6 +296,8 @@ func (o *GitHubOrgReconciler) getAndWaitForFinishedAttachments(ctx context.Conte
 	timeout := time.After(timeoutAfter)
 	for {
 		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
 		case <-timeout:
 			return nil, fmt.Errorf("timeout waiting for code security configuration attachment to complete")
 		case <-ticker.C:
@@ -349,12 +357,15 @@ func (o *GitHubOrgReconciler) attachToRepos(ctx context.Context, attachmentScope
 	if err != nil {
 		var acceptedErr *github.AcceptedError
 		if errors.As(err, &acceptedErr) {
-			if _, err := o.getAndWaitForFinishedAttachments(ctx, cscGitHubID, 5*time.Second, 2*time.Minute); err != nil {
-				log.Error(err, fmt.Sprintf("Attaching for code security configuration to repositories with scope %s failed either because of an error or it did not finish in time", attachmentScope))
-				return err
+			// Attachment was accepted and is processing asynchronously - wait for it to finish
+			log.V(1).Info("Attachment accepted, waiting for completion", "scope", attachmentScope)
+			if _, waitErr := o.getAndWaitForFinishedAttachments(ctx, cscGitHubID, 5*time.Second, 2*time.Minute); waitErr != nil {
+				log.Error(waitErr, "Attaching code security configuration did not finish in time", "scope", attachmentScope)
+				return waitErr
 			}
+			return nil
 		}
-		log.Error(err, fmt.Sprintf("Failed to attach code security configuration to repositories with scope %s", attachmentScope))
+		log.Error(err, "Failed to attach code security configuration to repositories", "scope", attachmentScope)
 		return err
 	}
 	return nil
@@ -415,7 +426,7 @@ func (o *GitHubOrgReconciler) createCsc(ctx context.Context, conf *githubv1alpha
 	ghConf := mapper.ToGithubCodeSecurityConfiguration(conf)
 	result, err := o.GitHub.Client.CreateCodeSecurityConfigurationForOrg(ctx, o.GitHub.Resource, ghConf)
 	if err != nil {
-		log.Error(err, "Failed to update code security configuration on GitHub")
+		log.Error(err, "Failed to create code security configuration on GitHub")
 		return nil, err
 	}
 	if conf.Spec.DefaultForNewRepos != nil {


### PR DESCRIPTION
GitHub returns HTTP 409 for modifiying operations on code security operations while an async process for attaching a csc to repositories is ongoing.