### PR TITLE
perf(teamrec): avoid calling ListMembers inside loop

### DIFF
--- a/internal/reconciler/teamrec/rec_members.go
+++ b/internal/reconciler/teamrec/rec_members.go
@@ -54,6 +54,19 @@ func (t *GitHubTeamReconciler) reconcileTeamMembers(ctx context.Context) error {
 			memberSuffix = org.Spec.MemberSuffix
 		}
 
+		ghMembers, err := githubOrg.Client.ListMembers(ctx, githubOrg.Resource)
+		if err != nil {
+			log.Error(err, "failed to get members from GitHub")
+			return err
+		}
+
+		orgMembersByName := make(map[string]string, len(ghMembers))
+		for _, ghMember := range ghMembers {
+			if ghMember != nil && ghMember.Login != nil {
+				orgMembersByName[*ghMember.Login] = *ghMember.Login
+			}
+		}
+
 		for _, memberRef := range t.Kubernetes.Resource.Spec.Members {
 			memberRef += memberSuffix
 			log := log.WithValues("member", memberRef)
@@ -66,21 +79,7 @@ func (t *GitHubTeamReconciler) reconcileTeamMembers(ctx context.Context) error {
 				delete(membersToDelete, memberRef)
 				continue
 			} else {
-				ghMembers, err := githubOrg.Client.ListMembers(ctx, githubOrg.Resource)
-				if err != nil {
-					log.Error(err, "failed to get members from GitHub")
-					return err
-				}
-
-				found := false
-				for _, ghMember := range ghMembers {
-					if ghMember.Login != nil && *ghMember.Login == memberRef {
-						found = true
-						break
-					}
-				}
-
-				if found {
+				if _, found := orgMembersByName[memberRef]; found {
 					if err := githubOrg.Client.AddTeamMember(ctx, githubOrg.Resource, t.Team.GetSlug(), memberRef); err != nil {
 						log.Error(err, "failed to add member to team", "member", memberRef)
 						return err


### PR DESCRIPTION
## Description

This PR optimizes the Team reconciler by calling `ListMembers` only once. This will also consume less of the API rate-limit budget.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Chore (refactoring, CI changes, dependency updates, etc.)

## Checklist

- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have added/updated unit tests for any new or changed templates
- [x] I have updated documentation (README, CONTRIBUTING, values comments) if needed
- [x] I have updated the generated CRDs and Manifest

## Related Issues

<!-- Link related issues: Fixes #123, Relates to #456 -->