### PR TITLE
fix: support renaming repos

### DIFF
--- a/internal/ghclient/interface.go
+++ b/internal/ghclient/interface.go
@@ -33,6 +33,7 @@ type GitHubClient interface {
 	// Repository operations
 	GetOrgRepositories(ctx context.Context, org string) ([]*github.Repository, error)
 	GetRepository(ctx context.Context, owner, repo string) (*github.Repository, error)
+	GetRepositoryByID(ctx context.Context, id int64) (*github.Repository, error)
 	CreateRepository(ctx context.Context, org string, repo *github.Repository) (*github.Repository, error)
 	EditRepository(ctx context.Context, owner, repo string, repository *github.Repository) (*github.Repository, error)
 	DeleteRepository(ctx context.Context, owner, repo string) error

--- a/internal/ghclient/wrapper.go
+++ b/internal/ghclient/wrapper.go
@@ -63,6 +63,12 @@ func (g *GitHubClientWrapper) GetRepository(ctx context.Context, owner, repo str
 	return result, _handleErrorResponse(response, err)
 }
 
+func (g *GitHubClientWrapper) GetRepositoryByID(ctx context.Context, id int64) (*github.Repository, error) {
+	result, response, err := g.client.Repositories.GetByID(ctx, id)
+	defer _closeBody(response)
+	return result, _handleErrorResponse(response, err)
+}
+
 func (g *GitHubClientWrapper) CreateRepository(ctx context.Context, org string, repo *github.Repository) (*github.Repository, error) {
 	result, response, err := g.client.Repositories.Create(ctx, org, repo)
 	defer _closeBody(response)

--- a/internal/reconciler/reporec/rec_repo.go
+++ b/internal/reconciler/reporec/rec_repo.go
@@ -58,7 +58,17 @@ func (r *GitHubRepoReconciler) reconcileRepository(ctx context.Context) error {
 
 func (r *GitHubRepoReconciler) getRepo(ctx context.Context) (*github.Repository, error) {
 	log := logPkg.FromContext(ctx)
-	ghRepo, err := r.GitHub.Client.GetRepository(ctx, r.GitHub.Resource.Owner, r.GitHub.Resource.Name)
+	var ghRepo *github.Repository
+	var err error
+	storedID := r.K8s().Resource.Status.ID
+	if storedID != nil {
+		ghRepo, err = r.GitHub.Client.GetRepositoryByID(ctx, *storedID)
+		log.V(1).Info("Repository identified by ID in status", "id", *storedID)
+	}
+	if ghRepo == nil { // do not use 'else' to try again if GetRepositoryByID fails
+		ghRepo, err = r.GitHub.Client.GetRepository(ctx, r.GitHub.Resource.Owner, r.GitHub.Resource.Name)
+		log.V(1).Info("Repository identified by name and owner")
+	}
 	if err != nil {
 		var ghErr *github.ErrorResponse
 		if errors.As(err, &ghErr) && ghErr.Response.StatusCode == http.StatusNotFound {
@@ -81,7 +91,7 @@ func (r *GitHubRepoReconciler) getRepo(ctx context.Context) (*github.Repository,
 			return nil, err
 		}
 	}
-	err = r.updateID(ctx, ghRepo)
+	err = r.updateRecFieldsFromGitHub(ctx, ghRepo)
 	if err != nil {
 		log.Error(err, "failed to update repository status in Kubernetes")
 		return nil, err
@@ -117,7 +127,7 @@ func (r *GitHubRepoReconciler) updateRepo(ctx context.Context) (*github.Reposito
 		log.Error(err, "failed to update repository on GitHub")
 		return ghRepo, err
 	}
-	err = r.updateID(ctx, ghRepo)
+	err = r.updateRecFieldsFromGitHub(ctx, ghRepo)
 	if err != nil {
 		log.Error(err, "failed to update repository status in Kubernetes")
 		return ghRepo, err
@@ -125,10 +135,11 @@ func (r *GitHubRepoReconciler) updateRepo(ctx context.Context) (*github.Reposito
 	return ghRepo, err
 }
 
-func (r *GitHubRepoReconciler) updateID(_ context.Context, ghRepo *github.Repository) error {
-	if ghRepo == nil || ghRepo.ID == nil {
-		return errors.New("unable to update repository ID with nil repository or nil ID")
+func (r *GitHubRepoReconciler) updateRecFieldsFromGitHub(_ context.Context, ghRepo *github.Repository) error {
+	if ghRepo == nil || ghRepo.ID == nil || ghRepo.Name == nil {
+		return errors.New("unable to update reconciler fields with nil data")
 	}
+	r.GitHub.Resource.Name = ghRepo.GetName()
 	r.GitHub.Resource.ID = ghRepo.ID
 	r.Kubernetes.Resource.Status.ID = ghRepo.ID
 	return nil

--- a/internal/reconciler/reporec/rec_repo_test.go
+++ b/internal/reconciler/reporec/rec_repo_test.go
@@ -416,7 +416,7 @@ var _ = Describe("ReconcileRepository", func() {
 
 		It("should return an error", func() {
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("unable to update repository ID"))
+			Expect(err.Error()).To(ContainSubstring("unable to update reconciler fields with nil data"))
 		})
 	})
 
@@ -429,7 +429,7 @@ var _ = Describe("ReconcileRepository", func() {
 
 		It("should return an error", func() {
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("unable to update repository ID"))
+			Expect(err.Error()).To(ContainSubstring("unable to update reconciler fields with nil data"))
 		})
 	})
 
@@ -669,6 +669,73 @@ var _ = Describe("ReconcileRepository", func() {
 			Expect(createdRepo.Archived).To(BeNil())
 		})
 	})
+
+	Context("when the repository was renamed via spec.name", func() {
+		// Simulates the factory setting rec.GitHub.Resource.Name from repo.Spec.Name (the new desired name),
+		// while the repository on GitHub still exists under its old name and Status.ID is already populated.
+		BeforeEach(func() {
+			repo.Spec.Name = "new-repo-name"
+			repo.Status.ID = new(int64(12345))
+
+			currentGHRepo = &github.Repository{
+				Name:       new("old-repo-name"),
+				Visibility: new("internal"),
+				Archived:   new(false),
+				ID:         new(int64(12345)),
+			}
+
+			mockClient.GetRepositoryByIDFunc = func(ctx context.Context, id int64) (*github.Repository, error) {
+				return currentGHRepo, nil
+			}
+		})
+
+		JustBeforeEach(func() {
+			k8sClient = fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(repo).
+				WithStatusSubresource(repo).
+				Build()
+
+			rec = &GitHubRepoReconciler{
+				GitHub: reconciler.GitHub[GitHubRepoIdentifier]{
+					Client: mockClient,
+					Resource: GitHubRepoIdentifier{
+						Owner: "test-org",
+						Name:  repo.Spec.Name, // mirrors what the factory does
+					},
+				},
+				Kubernetes: reconciler.Kubernetes[*v1alpha1.Repository]{
+					Client:   k8sClient,
+					Resource: repo,
+				},
+			}
+
+			err = rec.reconcileRepository(ctx)
+		})
+
+		It("should not create a duplicate repository", func() {
+			Expect(err).NotTo(HaveOccurred())
+			Expect(createRepoCalled).To(BeFalse())
+		})
+
+		It("should call EditRepository using the current (old) name and the new name in the body", func() {
+			Expect(err).NotTo(HaveOccurred())
+			Expect(editRepoCalled).To(BeTrue())
+			Expect(editedRepo).NotTo(BeNil())
+			Expect(editedRepo.GetName()).To(Equal("new-repo-name"))
+		})
+
+		It("should end up with the new name on the reconciler's GitHub resource", func() {
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rec.GitHub.Resource.Name).To(Equal("new-repo-name"))
+		})
+
+		It("should keep the same repository ID in status", func() {
+			Expect(err).NotTo(HaveOccurred())
+			Expect(repo.Status.ID).NotTo(BeNil())
+			Expect(*repo.Status.ID).To(Equal(int64(12345)))
+		})
+	})
 })
 
 var _ = Describe("getRepo", func() {
@@ -844,6 +911,108 @@ var _ = Describe("getRepo", func() {
 			Expect(ghRepo).To(BeNil())
 		})
 	})
+
+	Context("when a repository ID is stored in status", func() {
+		var (
+			getByIDCalled   bool
+			getByNameCalled bool
+		)
+
+		BeforeEach(func() {
+			repo.Status.ID = new(int64(12345))
+			getByIDCalled = false
+			getByNameCalled = false
+
+			mockClient.GetRepositoryByIDFunc = func(ctx context.Context, id int64) (*github.Repository, error) {
+				getByIDCalled = true
+				Expect(id).To(Equal(int64(12345)))
+				return &github.Repository{
+					Name:       new("test-repo"),
+					Visibility: new("internal"),
+					Archived:   new(false),
+					ID:         new(int64(12345)),
+				}, nil
+			}
+			mockClient.GetRepositoryFunc = func(ctx context.Context, owner, name string) (*github.Repository, error) {
+				getByNameCalled = true
+				return &github.Repository{
+					Name:       new("test-repo"),
+					Visibility: new("internal"),
+					Archived:   new(false),
+					ID:         new(int64(12345)),
+				}, nil
+			}
+
+			ghRepo, err = rec.getRepo(ctx)
+		})
+
+		It("should look up the repository by ID and skip the name-based lookup", func() {
+			Expect(err).NotTo(HaveOccurred())
+			Expect(getByIDCalled).To(BeTrue())
+			Expect(getByNameCalled).To(BeFalse())
+			Expect(ghRepo).NotTo(BeNil())
+			Expect(ghRepo.GetID()).To(Equal(int64(12345)))
+		})
+	})
+
+	Context("when the stored repository ID lookup does not find a repository", func() {
+		BeforeEach(func() {
+			repo.Status.ID = new(int64(99999))
+
+			mockClient.GetRepositoryByIDFunc = func(ctx context.Context, id int64) (*github.Repository, error) {
+				return nil, nil
+			}
+			mockClient.GetRepositoryFunc = func(ctx context.Context, owner, name string) (*github.Repository, error) {
+				getRepoCalled = true
+				return &github.Repository{
+					Name:       new("test-repo"),
+					Visibility: new("internal"),
+					Archived:   new(false),
+					ID:         new(int64(12345)),
+				}, nil
+			}
+
+			ghRepo, err = rec.getRepo(ctx)
+		})
+
+		It("should fall back to the name-based lookup", func() {
+			Expect(err).NotTo(HaveOccurred())
+			Expect(getRepoCalled).To(BeTrue())
+			Expect(ghRepo).NotTo(BeNil())
+			Expect(ghRepo.GetID()).To(Equal(int64(12345)))
+		})
+	})
+
+	Context("when the repository was renamed on GitHub", func() {
+		BeforeEach(func() {
+			// rec.GitHub.Resource.Name still holds the desired (new) name from spec.Name,
+			// but the repository was renamed on GitHub, so the ID-based lookup must be used
+			// to find it and the actual (old) current name must be adopted.
+			repo.Status.ID = new(int64(12345))
+
+			mockClient.GetRepositoryByIDFunc = func(ctx context.Context, id int64) (*github.Repository, error) {
+				return &github.Repository{
+					Name:       new("old-name"),
+					Visibility: new("internal"),
+					Archived:   new(false),
+					ID:         new(int64(12345)),
+				}, nil
+			}
+
+			ghRepo, err = rec.getRepo(ctx)
+		})
+
+		It("should return the repository under its current (old) name", func() {
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ghRepo).NotTo(BeNil())
+			Expect(ghRepo.GetName()).To(Equal("old-name"))
+		})
+
+		It("should update the GitHub resource identifier to the current name", func() {
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rec.GitHub.Resource.Name).To(Equal("old-name"))
+		})
+	})
 })
 
 var _ = Describe("updateRepo", func() {
@@ -937,7 +1106,7 @@ var _ = Describe("updateRepo", func() {
 	})
 })
 
-var _ = Describe("updateID", func() {
+var _ = Describe("updateRecFieldsFromGitHub", func() {
 	var (
 		ctx        context.Context
 		mockClient *ghclientmock.MockGitHubClientWrapper
@@ -999,7 +1168,7 @@ var _ = Describe("updateID", func() {
 				ID:   new(int64(54321)),
 			}
 
-			err = rec.updateID(ctx, ghRepo)
+			err = rec.updateRecFieldsFromGitHub(ctx, ghRepo)
 		})
 
 		It("should not return an error", func() {
@@ -1022,15 +1191,33 @@ var _ = Describe("updateID", func() {
 		})
 	})
 
+	Context("when repository has a different name than currently stored", func() {
+		BeforeEach(func() {
+			ghRepo = &github.Repository{
+				Name: new("renamed-repo"),
+				ID:   new(int64(54321)),
+			}
+
+			err = rec.updateRecFieldsFromGitHub(ctx, ghRepo)
+		})
+
+		It("should not return an error", func() {
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should update the Name in GitHub resource", func() {
+			Expect(rec.GitHub.Resource.Name).To(Equal("renamed-repo"))
+		})
+	})
+
 	Context("when repository is nil", func() {
 		BeforeEach(func() {
-			err = rec.updateID(ctx, nil)
+			err = rec.updateRecFieldsFromGitHub(ctx, nil)
 		})
 
 		It("should return an error", func() {
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("unable to update repository ID"))
-			Expect(err.Error()).To(ContainSubstring("nil repository"))
+			Expect(err.Error()).To(ContainSubstring("unable to update reconciler fields with nil data"))
 		})
 	})
 
@@ -1041,13 +1228,28 @@ var _ = Describe("updateID", func() {
 				ID:   nil,
 			}
 
-			err = rec.updateID(ctx, ghRepo)
+			err = rec.updateRecFieldsFromGitHub(ctx, ghRepo)
 		})
 
 		It("should return an error", func() {
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("unable to update repository ID"))
-			Expect(err.Error()).To(ContainSubstring("nil ID"))
+			Expect(err.Error()).To(ContainSubstring("unable to update reconciler fields with nil data"))
+		})
+	})
+
+	Context("when repository Name is nil", func() {
+		BeforeEach(func() {
+			ghRepo = &github.Repository{
+				Name: nil,
+				ID:   new(int64(54321)),
+			}
+
+			err = rec.updateRecFieldsFromGitHub(ctx, ghRepo)
+		})
+
+		It("should return an error", func() {
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("unable to update reconciler fields with nil data"))
 		})
 	})
 })

--- a/test/mock/ghclientmock/mock_factory.go
+++ b/test/mock/ghclientmock/mock_factory.go
@@ -47,6 +47,7 @@ type MockGitHubClientWrapper struct {
 
 	// Repository mocks
 	GetRepositoryFunc      func(ctx context.Context, owner, repo string) (*github.Repository, error)
+	GetRepositoryByIDFunc  func(ctx context.Context, id int64) (*github.Repository, error)
 	CreateRepositoryFunc   func(ctx context.Context, org string, repo *github.Repository) (*github.Repository, error)
 	EditRepositoryFunc     func(ctx context.Context, owner, repo string, repository *github.Repository) (*github.Repository, error)
 	DeleteRepositoryFunc   func(ctx context.Context, owner, repo string) error

--- a/test/mock/ghclientmock/mock_repository.go
+++ b/test/mock/ghclientmock/mock_repository.go
@@ -28,6 +28,17 @@ func (m *MockGitHubClientWrapper) GetRepository(ctx context.Context, owner, repo
 	}, nil
 }
 
+func (m *MockGitHubClientWrapper) GetRepositoryByID(ctx context.Context, id int64) (*github.Repository, error) {
+	m.recordRepoCall(RepoCall{Method: "GetRepositoryByID"})
+
+	if m.GetRepositoryByIDFunc != nil {
+		return m.GetRepositoryByIDFunc(ctx, id)
+	}
+
+	// Default implementation - not found, forces fallback to name-based lookup
+	return nil, nil
+}
+
 func (m *MockGitHubClientWrapper) CreateRepository(ctx context.Context, org string, repo *github.Repository) (*github.Repository, error) {
 	m.recordRepoCall(RepoCall{Method: "CreateRepository", Owner: org, Repo: repo.GetName()})
 


### PR DESCRIPTION
## Description

Fixes repository renaming support in the `Repository` reconciler. Previously, changing `spec.name` on an already-tracked `Repository` caused the reconciler to look up the repo by its (new) desired name, get a 404 from GitHub, and create a brand-new duplicate repository — silently orphaning the original repo under its old name.

`getRepo()` now prefers looking up the repository by its stable GitHub ID (`Status.ID`) via `GetRepositoryByID`, falling back to name-based lookup only when no ID is stored or the ID lookup finds nothing. Once the current repository is resolved, `r.GitHub.Resource.Name` is kept in sync with GitHub's actual current name (via the new `updateRecFieldsFromGitHub` helper, replacing `updateID`), so that:

- The rename diff is correctly detected by `mapper.RepoDiffers()`.
- `EditRepository` is called with the **current** (old) name in the URL path and the **new** name in the request body — matching GitHub's rename semantics (`PATCH /repos/{owner}/{current-name}` with `{"name": "new-name"}`).
- Subsequent reconciliation steps within the same run use the correct, up-to-date name.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Chore (refactoring, CI changes, dependency updates, etc.)

## Checklist

- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have added/updated unit tests for any new or changed templates
- [ ] I have updated documentation (README, CONTRIBUTING, values comments) if needed
- [ ] I have updated the generated files using `make codegen`

## Related Issues

<!-- Link related issues: Fixes #123, Relates to #456 -->